### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,10 @@ on:
       - "packages.install"
       - "packages.uninstall"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/real-LiHua/dotfiles/security/code-scanning/37](https://github.com/real-LiHua/dotfiles/security/code-scanning/37)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow does not appear to interact with repository contents or other GitHub features, we will set `contents: read` as the minimal permission. This ensures the workflow has only the necessary permissions to execute safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
